### PR TITLE
Fix numpy 1.16 FutureWarning

### DIFF
--- a/multistate_kernel/util.py
+++ b/multistate_kernel/util.py
@@ -230,10 +230,10 @@ class MultiStateData(object):
             if not len(v.x) == len(v.y) == len(v.err):
                 raise ValueError('{} key has different array shapes'.format(k))
         x = cls._x_2d_from_1d((v.x for v in itervalues(d)))
-        y = np.hstack((v.y for v in itervalues(d)))
+        y = np.hstack([v.y for v in itervalues(d)])
         norm = MultiStateData.__norm(y)
         y /= norm
-        err = np.hstack((v.err for v in itervalues(d))) / norm
+        err = np.hstack([v.err for v in itervalues(d)]) / norm
         return cls(d, ScikitLearnData(x=x, y=y, err=err, norm=norm))
 
     @classmethod


### PR DESCRIPTION
Passing any iterator to `np.*stack` is deprecated since `numpy` 1.16 (current version).
So now we should pass sequence instead of list comprehension (aka in-line
generator)
https://docs.scipy.org/doc/numpy-1.16.0/release.html#new-deprecations
https://github.com/numpy/numpy/blob/maintenance/1.16.x/numpy/core/shape_base.py#L209